### PR TITLE
jakarta updates

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -21,5 +21,10 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
            ${{ runner.os }}-maven-
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17.0.4+8'
+          distribution: 'adopt'           
       - name: Build with mvn
         run: mvn -B -ntp  clean install 

--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -19,84 +19,84 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>2.0.0</version>
+  <version>2.0.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
   <dependencies>
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
-      <version>1.6.2</version>
+      <version>1.6.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
-      <version>2.33</version>
+      <version>3.0.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-multipart</artifactId>
-      <version>2.33</version>
+      <version>3.0.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <version>2.33</version>
+      <version>3.0.9</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <artifactId>jackson-jaxrs-base</artifactId>
           <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>jackson-jaxrs-base</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.12.3</version>
+      <version>2.14.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <artifactId>jackson-annotations</artifactId>
           <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.12.3</version>
+      <version>2.14.2</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>
-          <artifactId>jackson-annotations</artifactId>
           <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-      <version>2.12.3</version>
+      <version>2.14.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-common</artifactId>
-      <version>2.33</version>
+      <version>3.0.9</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.ws.rs</groupId>
       <artifactId>jakarta.ws.rs-api</artifactId>
-      <version>2.1.6</version>
+      <version>3.0.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>2.0.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>jar</packaging>
     <name>swagger-java-zenodo-client</name>
     <groupId>io.dockstore</groupId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2</version>
 
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
@@ -61,7 +61,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>swagger-java-bitbucket-client-2.0.0</tag>
+        <tag>2.0.2</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -450,12 +450,6 @@
                             <token>javax.xml.bind</token>
                             <value>jakarta.xml.bind</value>
                         </replacement>
-                        <!--
-                        <replacement>
-                            <token>com.fasterxml.jackson.jaxrs.json</token>
-                            <value>com.fasterxml.jackson.jakarta.rs.json</value>
-                        </replacement>
-                        -->
                     </replacements>
                 </configuration>
             </plugin>	    	    	    

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.12.0-alpha.0</dockstore-core.version>
+        <dockstore-core.version>1.15.0-prealpha.1</dockstore-core.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
         <maven-surefire.version>2.21.0</maven-surefire.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
@@ -101,9 +101,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.10.1</version>
                     <configuration>
-                        <release>11</release>
+                        <release>17</release>
                         <showDeprecation>true</showDeprecation>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     </configuration>
@@ -147,14 +147,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>1.11.1</version>
-                        </dependency>
-                    </dependencies>
+                    <version>3.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -253,7 +246,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>3.1.12.2</version>
+                    <version>4.5.3.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -299,13 +292,13 @@
                 <plugin>
                     <groupId>io.swagger</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>2.4.19</version>
+                    <version>2.4.21</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/io.swagger.codegen.v3/swagger-codegen-maven-plugin -->
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.25</version>
+                    <version>3.0.36</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin -->
                 <plugin>
@@ -400,7 +393,72 @@
                     </execution>
                 </executions>
             </plugin>
-
+<plugin>
+                <groupId>com.google.code.maven-replacer-plugin</groupId>
+                <artifactId>replacer</artifactId>
+                <version>1.5.3</version>
+                <executions>
+                    <execution>
+                        <id>replace1</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                    <!-- not sure why swagger-codegen-maven-plugin runs in two phases -->
+                    <execution>
+                        <id>replace2</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>replace</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includes>
+                        <include>${pom.basedir}/target/generated-sources/swagger/src/gen/java/**/*.java</include>
+                        <include>${pom.basedir}/target/generated-sources/swagger/src/main/java/**/*.java</include>
+                    </includes>
+                    <regex>false</regex>
+                    <replacements>
+                        <!-- for these jakarta replacements, we can do better after https://github.com/swagger-api/swagger-codegen/issues/11797 -->
+                        <replacement>
+                            <token>javax.annotation</token>
+                            <value>jakarta.annotation</value>
+                        </replacement>
+                        <replacement>
+                            <token>@javax.annotation</token>
+                            <value>@jakarta.annotation</value>
+                        </replacement>
+                        <replacement>
+                            <token>javax.validation</token>
+                            <value>jakarta.validation</value>
+                        </replacement>
+                        <replacement>
+                            <token>javax.ws</token>
+                            <value>jakarta.ws</value>
+                        </replacement>
+                        <replacement>
+                            <token>javax.servlet</token>
+                            <value>jakarta.servlet</value>
+                        </replacement>
+                        <replacement>
+                            <token>javax.xml.bind</token>
+                            <value>jakarta.xml.bind</value>
+                        </replacement>
+                        <replacement>
+                            <token>javax.xml.bind</token>
+                            <value>jakarta.xml.bind</value>
+                        </replacement>
+                        <!--
+                        <replacement>
+                            <token>com.fasterxml.jackson.jaxrs.json</token>
+                            <value>com.fasterxml.jackson.jakarta.rs.json</value>
+                        </replacement>
+                        -->
+                    </replacements>
+                </configuration>
+            </plugin>	    	    	    
             <!-- auto-generated java classes should not fail the build on style -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
                     </execution>
                 </executions>
             </plugin>
-<plugin>
+            <plugin>
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>replacer</artifactId>
                 <version>1.5.3</version>
@@ -452,7 +452,7 @@
                         </replacement>
                     </replacements>
                 </configuration>
-            </plugin>	    	    	    
+            </plugin>
             <!-- auto-generated java classes should not fail the build on style -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>jar</packaging>
     <name>swagger-java-zenodo-client</name>
     <groupId>io.dockstore</groupId>
-    <version>2.0.2</version>
+    <version>2.0.3-SNAPSHOT</version>
 
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
@@ -61,7 +61,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>2.0.2</tag>
+        <tag>swagger-java-bitbucket-client-2.0.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>jar</packaging>
     <name>swagger-java-zenodo-client</name>
     <groupId>io.dockstore</groupId>
-    <version>2.0.1</version>
+    <version>2.0.2-SNAPSHOT</version>
 
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
@@ -61,7 +61,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>2.0.1</tag>
+        <tag>swagger-java-bitbucket-client-2.0.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>jar</packaging>
     <name>swagger-java-zenodo-client</name>
     <groupId>io.dockstore</groupId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1</version>
 
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
@@ -61,7 +61,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>swagger-java-bitbucket-client-2.0.0</tag>
+        <tag>2.0.1</tag>
     </scm>
 
     <licenses>

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -12,7 +12,7 @@ basePath: /api
 schemes:
   - https
 paths:
-  /communities:
+  /communities/:
     get:
       summary: List of communities
       description: ''
@@ -483,7 +483,7 @@ paths:
             type: object
         '405':
           description: Method Not Allowed
-  /grants:
+  /grants/:
     get:
       summary: List of grants
       description: ''
@@ -499,7 +499,7 @@ paths:
             type: object
         '405':
           description: Method Not Allowed
-  /licenses:
+  /licenses/:
     get:
       summary: List of licenses
       description: ''
@@ -515,7 +515,7 @@ paths:
             type: object
         '405':
           description: Method Not Allowed
-  /records:
+  /records/:
     get:
       summary: List of records
       description: ''


### PR DESCRIPTION
Update along the lines of https://github.com/dockstore/swagger-java-discourse-client/pull/15 
Will need manual testing, seems like the automated tests for zenodo are not up to snuff

Corrected some endpoint descriptions in openapi (yes, its silly but true, the ending slash is required and leads to ElasticSearch results)