### PR TITLE
extend test and fix api metadata

### DIFF
--- a/src/main/java/io/dockstore/EntryCreatorExample.java
+++ b/src/main/java/io/dockstore/EntryCreatorExample.java
@@ -70,7 +70,24 @@ public class EntryCreatorExample {
 
         String conceptDoiUrl = publishedDeposit.getLinks().get("parent_doi");
 
+        System.out.println("Success creating concept DOI");
         System.out.println(conceptDoiUrl);
+        System.out.println("Success creating first deposit");
         System.out.println(publishedDeposit);
+
+        // test out second deposit
+        testSecondDeposit(depositApi, actionsApi, publishedDeposit.getId());
+    }
+
+    public static void testSecondDeposit(DepositsApi depositApi, ActionsApi actionsApi, int depositID) {
+        Deposit returnDeposit = actionsApi.newDepositVersion(depositID);
+        String depositURL = returnDeposit.getLinks().get("latest_draft");
+        String depositionIDStr = depositURL.substring(depositURL.lastIndexOf("/") + 1).trim();
+        int depositionID = Integer.parseInt(depositionIDStr);
+        returnDeposit = depositApi.getDeposit(depositionID);
+        DepositMetadata depositMetadata = returnDeposit.getMetadata();
+        String doi = depositMetadata.getPrereserveDoi().getDoi();
+        System.out.println("Success creating second deposit");
+        System.out.println(doi);
     }
 }

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -647,6 +647,7 @@ definitions:
         type: string
       prereserve_doi:
         type: object
+        $ref: '#/definitions/PrereserveDoi'
       keywords:
         type: array
         items:
@@ -726,6 +727,13 @@ definitions:
       - creators
       - description
       - access_right
+  PrereserveDoi:
+    type: object
+    properties:
+      doi:
+        type: string
+      recid:
+        type: integer
   Subject:
     type: object
     properties:


### PR DESCRIPTION
**Description**
Seeing a slightly different issue with second (third, forth) DOIs for different workflow versions
`[HTTP 500] OK: There was an error processing your request. It has been logged (ID ad41600f2297618f).`
Looks like this is a variant of https://github.com/dockstore/zenodo-client/pull/27

An api change on the zenodo end broke our code for issuing follow-up DOIs linked to a previous concept DOI
This is a proper fix for the issue, but may be a bit risky so leaving it here for a future dockstore version

**Review Instructions**
Run the EntryCreatorExample with a token from sandbox.zenodo.org

**Issue**
https://github.com/dockstore/dockstore/issues/5792

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
