### PR TITLE
Add the concept DOI to SearchResult

### DIFF
--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.dockstore</groupId>
   <artifactId>swagger-java-zenodo-client</artifactId>
-  <version>2.0.5-SNAPSHOT</version>
+  <version>2.1.3-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache Software License, Version 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dockstore-core.version>1.16.0-alpha.13</dockstore-core.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
-        <maven-surefire.version>3.0.0-M5</maven-surefire.version>
+        <maven-surefire.version>3.4.0</maven-surefire.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
         <jersey-version>3.0.11</jersey-version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,10 @@
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.15.0-beta.0</dockstore-core.version>
+        <dockstore-core.version>1.16.0-alpha.13</dockstore-core.version>
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
-        <maven-surefire.version>2.21.0</maven-surefire.version>
+        <maven-surefire.version>3.0.0-M5</maven-surefire.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-        <junit-version>4.12</junit-version>
         <jersey-version>3.0.11</jersey-version>
     </properties>
 

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -1023,6 +1023,8 @@ definitions:
         type: string
       doi_url:
         type: string
+      conceptdoi:
+        type: string
       metadata:
         type: object
         properties:

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -1,19 +1,39 @@
 package io.dockstore;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.swagger.zenodo.client.ApiClient;
+import io.swagger.zenodo.client.model.SearchResult;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-
-
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class ZenodoClientTest {
 
-    @org.junit.jupiter.api.Test
-    public void testZenodoClient() throws io.swagger.zenodo.client.ApiException {
-        io.swagger.zenodo.client.ApiClient client = new io.swagger.zenodo.client.ApiClient();
+    private static ApiClient client;
+    private static io.swagger.zenodo.client.api.PreviewApi previewApi;
+
+    @BeforeAll
+    static void setup() {
+        client = new ApiClient();
         client.setBasePath("https://sandbox.zenodo.org/api");
-        io.swagger.zenodo.client.api.PreviewApi previewApi = new io.swagger.zenodo.client.api.PreviewApi(client);
+        previewApi = new io.swagger.zenodo.client.api.PreviewApi(client);
+    }
+
+    @Test
+    @Disabled("Test disabled as the communities API is failing on sandbox")
+    public void testZenodoClient() throws io.swagger.zenodo.client.ApiException {
         HashMap<String, Object> o = (HashMap<String, Object>)previewApi.listCommunities();
         assertTrue(o != null && !o.keySet().isEmpty(), "not able to list communities as basic test");
+    }
+
+    @Test
+    void testConceptDoi() {
+        final SearchResult searchResult = previewApi.listRecords(null, "bestmatch", 1, 100);
+        assertNotNull(searchResult.getHits().getHits().get(0).getConceptdoi());
     }
 }

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -4,21 +4,21 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.swagger.zenodo.client.ApiClient;
+import io.swagger.zenodo.client.ApiException;
+import io.swagger.zenodo.client.api.PreviewApi;
 import io.swagger.zenodo.client.model.SearchResult;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class ZenodoClientTest {
 
-    private static ApiClient client;
-    private static io.swagger.zenodo.client.api.PreviewApi previewApi;
+    private ApiClient client;
+    private PreviewApi previewApi;
 
-    @BeforeAll
-    static void setup() {
+    @BeforeEach
+    void setup() {
         client = new ApiClient();
         client.setBasePath("https://sandbox.zenodo.org/api");
         previewApi = new io.swagger.zenodo.client.api.PreviewApi(client);
@@ -26,7 +26,7 @@ public class ZenodoClientTest {
 
     @Test
     @Disabled("Test disabled as the communities API is failing on sandbox")
-    public void testZenodoClient() throws io.swagger.zenodo.client.ApiException {
+    public void testZenodoClient() throws ApiException {
         HashMap<String, Object> o = (HashMap<String, Object>)previewApi.listCommunities();
         assertTrue(o != null && !o.keySet().isEmpty(), "not able to list communities as basic test");
     }


### PR DESCRIPTION
**Description**
When working on  dockstore/dockstore#5745, I realized I didn't surface the conceptdoi in the `SearchResult`. Surfacing it there can save as an additional API request.

**Review Instructions**
Review instructions will be in dockstore/dockstore#5880; it should be reviewed in the context of the whole flow.

**Issue**
dockstore/dockstore#5745
DOCK-2493

**Security and Privacy**

If there are any concerns that require extra attention from the security team, highlight them here.

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
