### PR TITLE
Feature/html conversion

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '17.0.4+8'
+          java-version: '21.0.2+13.0.LTS'
           distribution: 'adopt'           
       - name: Build with mvn
         run: ./mvnw -B -ntp  clean install

--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -99,6 +99,12 @@
       <version>3.1.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.24.0</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -26,12 +26,13 @@
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.15.0-beta.0</dockstore-core.version>
-        <maven-failsafe.version>2.21.0</maven-failsafe.version>
-        <maven-surefire.version>2.21.0</maven-surefire.version>
+        <dockstore-core.version>1.16.6</dockstore-core.version>
+        <maven-surefire.version>3.4.0</maven-surefire.version>
+        <maven-failsafe.version>2.22.2</maven-failsafe.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-        <junit-version>4.12</junit-version>
-        <jersey-version>3.0.11</jersey-version>
+        <junit-version>4.13.2</junit-version>
+        <jersey.version>3.0.17</jersey.version>
+        <maven-java.version>17</maven-java.version>
     </properties>
 
     <dependencyManagement>
@@ -63,7 +64,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>swagger-java-bitbucket-client-2.0.0</tag>
+        <tag>swagger-java-zenodo-client-2.0.3</tag>
     </scm>
 
     <licenses>
@@ -88,7 +89,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.5</version>
+                    <version>0.8.11</version>
                 </plugin>
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>
@@ -103,9 +104,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.12.1</version>
                     <configuration>
-                        <release>17</release>
+                        <release>${maven-java.version}</release>
                         <showDeprecation>true</showDeprecation>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     </configuration>
@@ -113,7 +114,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.2</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -130,13 +131,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <!-- codacy currently using 8.34 -->
-                            <version>8.34</version>
+                            <version>10.0</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -149,7 +149,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -248,7 +248,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.5.3.0</version>
+                    <version>4.8.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -274,7 +274,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -284,7 +284,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>4.4.1</version>
+                    <version>4.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -294,13 +294,13 @@
                 <plugin>
                     <groupId>io.swagger</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>2.4.21</version>
+                    <version>2.4.32</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/io.swagger.codegen.v3/swagger-codegen-maven-plugin -->
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.36</version>
+                    <version>3.0.46</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin -->
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -659,5 +659,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.24.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/dockstore/EntryCreatorExample.java
+++ b/src/main/java/io/dockstore/EntryCreatorExample.java
@@ -18,6 +18,10 @@ import io.swagger.zenodo.client.model.DepositMetadata;
 import io.swagger.zenodo.client.model.DepositionFile;
 import io.swagger.zenodo.client.model.NestedDepositMetadata;
 import io.swagger.zenodo.client.model.RelatedIdentifier;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import java.util.List;
 
 public class EntryCreatorExample {
 
@@ -46,14 +50,102 @@ public class EntryCreatorExample {
         System.out.println(file);
 
         // add some metadata
+        returnDeposit.getMetadata().setPublicationDate("2025-03-03");
         returnDeposit.getMetadata().setTitle("foobar title");
         returnDeposit.getMetadata().setUploadType(DepositMetadata.UploadTypeEnum.POSTER);
-        returnDeposit.getMetadata().setDescription("This is a first upload");
+        // just above https://developers.zenodo.org/#list
+        // there's a note that says " For string fields that allow HTML (e.g. description, notes), for security reasons, only the following tags are accepted: a, abbr, acronym, b, blockquote, br, code, caption, div, em, i, li, ol, p, pre, span, strike, strong, sub, table, caption, tbody, thead, th, td, tr, u, ul. "
+        String descriptionHTML = """
+                <b>This text is bold</b>
+                <strike>This text is scratched out</strike>
+                <p>
+                <strike>This text is also scratched out, but in a new paragraph</strike>            
+            """;
+
+        String descriptionMarkdown = """
+            commonmark-java
+            ===============
+                        
+            Java library for parsing and rendering [Markdown] text according to the
+            [CommonMark] specification (and some extensions).
+                        
+            [![Maven Central status](https://img.shields.io/maven-central/v/org.commonmark/commonmark.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.commonmark%22)
+            [![javadoc](https://www.javadoc.io/badge/org.commonmark/commonmark.svg?color=blue)](https://www.javadoc.io/doc/org.commonmark/commonmark)
+            [![ci](https://github.com/commonmark/commonmark-java/workflows/ci/badge.svg)](https://github.com/commonmark/commonmark-java/actions?query=workflow%3Aci)
+            [![codecov](https://codecov.io/gh/commonmark/commonmark-java/branch/main/graph/badge.svg)](https://codecov.io/gh/commonmark/commonmark-java)
+            [![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/commonmarkcommonmarkjava/)
+                        
+            Introduction
+            ------------
+                        
+            Provides classes for parsing input to an abstract syntax tree (AST),
+            visiting and manipulating nodes, and rendering to HTML or back to Markdown.
+            It started out as a port of [commonmark.js], but has since evolved into an
+            extensible library with the following features:
+                        
+            * Small (core has no dependencies, extensions in separate artifacts)
+            * Fast (10-20 times faster than [pegdown] which used to be a popular Markdown
+              library, see benchmarks in repo)
+            * Flexible (manipulate the AST after parsing, customize HTML rendering)
+            * Extensible (tables, strikethrough, autolinking and more, see below)
+                        
+            The library is supported on Java 11 and later. It works on Android too,
+            but that is on a best-effort basis, please report problems. For Android the
+            minimum API level is 19, see the
+            [commonmark-android-test](commonmark-android-test)
+            directory.
+                        
+            Coordinates for core library (see all on [Maven Central]):
+                        
+            ```xml
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark</artifactId>
+                <version>0.24.0</version>
+            </dependency>
+            ```
+                        
+            The module names to use in Java 9 are `org.commonmark`,
+            `org.commonmark.ext.autolink`, etc, corresponding to package names.
+                        
+            Note that for 0.x releases of this library, the API is not considered stable
+            yet and may break between minor releases. After 1.0, [Semantic Versioning] will
+            be followed. A package containing `beta` means it's not subject to stable API
+            guarantees yet; but for normal usage it should not be necessary to use.
+                        
+            See the [spec.txt](commonmark-test-util/src/main/resources/spec.txt)
+            file if you're wondering which version of the spec is currently
+            implemented. Also check out the [CommonMark dingus] for getting familiar
+            with the syntax or trying out edge cases. If you clone the repository,
+            you can also use the `DingusApp` class to try out things interactively.
+                        
+                        
+            Usage
+            -----
+                        
+            #### Parse and render to HTML
+                        
+            ```java
+            import org.commonmark.node.*;
+            import org.commonmark.parser.Parser;
+            import org.commonmark.renderer.html.HtmlRenderer;
+                        
+            Parser parser = Parser.builder().build();
+            Node document = parser.parse("This is *Markdown*");
+            HtmlRenderer renderer = HtmlRenderer.builder().build();
+            renderer.render(document);  // "<p>This is <em>Markdown</em></p>\\n"
+            """;
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse(descriptionMarkdown);
+        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        descriptionHTML = renderer.render(document);  // "<p>This is <em>Markdown</em></p>\n"
+
+        returnDeposit.getMetadata().setDescription(descriptionHTML);
 
         RelatedIdentifier relatedIdentifier = new RelatedIdentifier();
         relatedIdentifier.setIdentifier("https://dockstore.org/containers/quay.io%2Fpancancer%2Fpcawg-sanger-cgp-workflow");
         relatedIdentifier.setRelation(RelatedIdentifier.RelationEnum.ISIDENTICALTO);
-        returnDeposit.getMetadata().setRelatedIdentifiers(Arrays.asList(relatedIdentifier));
+        returnDeposit.getMetadata().setRelatedIdentifiers(List.of(relatedIdentifier));
 
         Author author1 = new Author();
         author1.setName("lastname1, firstname1");


### PR DESCRIPTION
**Description**
Update to newer dockstore core, compatibility with Java 21
But mainly testing Markdown to HTML conversion for deposits without having to do a full Dockstore release

e.g..
![Screenshot from 2025-04-01 14-31-40](https://github.com/user-attachments/assets/1327a22d-5c65-46d7-96aa-2ab996a6e32f)


**Review Instructions**
Can run `EntryCreatorExample` with an access token from zenodo sandbox

**Issue**
https://github.com/dockstore/dockstore/issues/6088

**Security and Privacy**

None

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
