### PR TITLE
 zenodo draft deletion scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,11 +262,16 @@
                             </goals>
                             <configuration>
                                 <transformers>
-                                    <!-- Akka used by Cromwell expects a consistant reference.conf file.  Also order matters, so keep it first in the list of transformers -->
+                                    <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                         <resource>reference.conf</resource>
                                     </transformer>
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                        <mainClass>io.dockstore.DraftCleanup</mainClass>
+                                    </transformer>
                                 </transformers>
+                                <createDependencyReducedPom>false</createDependencyReducedPom>
                             </configuration>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -253,28 +253,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                            <configuration>
-                                <transformers>
-                                    <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                        <resource>reference.conf</resource>
-                                    </transformer>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                        <mainClass>io.dockstore.DraftCleanup</mainClass>
-                                    </transformer>
-                                </transformers>
-                                <createDependencyReducedPom>false</createDependencyReducedPom>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -595,6 +574,33 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>reference.conf</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>io.dockstore.DraftCleanup</Main-Class>
+                                    </manifestEntries>
+                                    <mainClass>io.dockstore.DraftCleanup</mainClass>
+                                </transformer>
+                            </transformers>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/dockstore/EntryCreatorExample.java
+++ b/src/main/java/io/dockstore/EntryCreatorExample.java
@@ -160,7 +160,7 @@ public class EntryCreatorExample {
         ActionsApi actionsApi = new ActionsApi(client);
         Deposit publishedDeposit = actionsApi.publishDeposit(depositionID);
 
-        String conceptDoiUrl = publishedDeposit.getLinks().get("parent_doi");
+        String conceptDoiUrl = publishedDeposit.getLinks().getParentDoi();
 
         System.out.println("Success creating concept DOI");
         System.out.println(conceptDoiUrl);
@@ -173,7 +173,7 @@ public class EntryCreatorExample {
 
     public static void testSecondDeposit(DepositsApi depositApi, ActionsApi actionsApi, int depositID) {
         Deposit returnDeposit = actionsApi.newDepositVersion(depositID);
-        String depositURL = returnDeposit.getLinks().get("latest_draft");
+        String depositURL = returnDeposit.getLinks().getLatestDraft();
         String depositionIDStr = depositURL.substring(depositURL.lastIndexOf("/") + 1).trim();
         int depositionID = Integer.parseInt(depositionIDStr);
         returnDeposit = depositApi.getDeposit(depositionID);

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -695,8 +695,37 @@ definitions:
         type: integer
       links:
         type: object
-        additionalProperties:
-          type: string
+        properties:
+          conceptdoi:
+            type: string
+          self:
+            type: string
+          html:
+            type: string
+          badge:
+            type: string
+          files:
+            type: string
+          bucket:
+            type: string
+          thumb250:
+            type: string
+          thumbs:
+            type: object
+          latest_draft:
+            type: string
+          latest_draft_html:
+            type: string
+          publish:
+            type: string
+          edit:
+            type: string
+          discard:
+            type: string
+          newversion:
+            type: string
+          parent_doi:
+            type: string
         example:
           conceptdoi: https://doi.org/10.5281/zenodo.705645
       metadata:

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -531,6 +531,84 @@ paths:
             type: object
         '405':
           description: Method Not Allowed
+  /records/{depositId}/draft:
+    delete:
+      summary: Delete a draft deposit
+      description: ''
+      operationId: deleteDraftRecord
+      security:
+        - access_token: []
+      tags:
+        - preview
+      parameters:
+        - in: path
+          name: depositId
+          type: integer
+          required: true
+      responses:
+        '204':
+          description: OK
+        '405':
+          description: Method Not Allowed
+  /user/records:
+    get:
+      summary: List of records for a specific user
+      description: ''
+      operationId: listUserRecords
+      security:
+        - access_token: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query used to filter results based on ElasticSearch's
+            query string syntax.
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            'Sort search results. Customizable. Built-in options are "bestmatch",
+                  "newest", "oldest", "updated-desc", "updated-asc", "version", "mostviewed",
+                  "mostdownloaded" (default: "bestmatch" or "newest").'
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Specify number of items in the results page (default: 10)."
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Specify the page of results.
+        - name: allversions
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: "Specify if all versions should be included (default: False, displays just latest version)."
+        - name: shared_with_me
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: "Seems like undocumented parameter to control if you see everyone's records or just your own"
+      tags:
+        - preview
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Records'
+        '405':
+          description: Method Not Allowed
 securityDefinitions:
   zenodo_auth:
     type: oauth2
@@ -546,6 +624,61 @@ securityDefinitions:
     name: access_token
     in: query
 definitions:
+  Records:
+    type: object
+    properties:
+      hits:
+        $ref: '#/definitions/Hits'
+      aggregations:
+        type: object
+      links:
+        type: object
+  Hits:
+    type: object
+    properties:
+      hits:
+        type: array
+        items:
+          $ref: '#/definitions/Hit'
+      total:
+        type: integer
+  Hit:
+    description: returned by records search, looks a lot like a Deposit but subtly isn't
+    type: object
+    properties:
+      conceptrecid:
+        type: integer
+      created:
+        type: string
+        format: date-time
+      files:
+        type: array
+        items:
+          $ref: '#/definitions/DepositionFile'
+      id:
+        type: integer
+      links:
+        type: object
+        additionalProperties:
+          type: string
+        example:
+          conceptdoi: https://doi.org/10.5281/zenodo.705645
+      modified:
+        type: string
+        format: date-time
+      owner:
+        type: integer
+      record_id:
+        type: integer
+      state:
+        type: string
+      status:
+        type: string
+        description: oddly, this field is populated in a list of records but not when retriving individual deposits
+      submitted:
+        type: boolean
+      title:
+        type: string
   Deposit:
     type: object
     properties:

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -1,19 +1,64 @@
 package io.dockstore;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.swagger.zenodo.client.ApiClient;
+import io.swagger.zenodo.client.ApiException;
+import io.swagger.zenodo.client.api.DepositsApi;
+import io.swagger.zenodo.client.api.PreviewApi;
+import io.swagger.zenodo.client.model.Deposit;
+import io.swagger.zenodo.client.model.Hit;
+import io.swagger.zenodo.client.model.Hits;
+import io.swagger.zenodo.client.model.Records;
 import java.util.HashMap;
-
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 
 public class ZenodoClientTest {
 
-    @org.junit.jupiter.api.Test
+    @Test
     public void testZenodoClient() throws io.swagger.zenodo.client.ApiException {
-        io.swagger.zenodo.client.ApiClient client = new io.swagger.zenodo.client.ApiClient();
+        ApiClient client = new ApiClient();
         client.setBasePath("https://sandbox.zenodo.org/api");
-        io.swagger.zenodo.client.api.PreviewApi previewApi = new io.swagger.zenodo.client.api.PreviewApi(client);
+        PreviewApi previewApi = new PreviewApi(client);
         HashMap<String, Object> o = (HashMap<String, Object>)previewApi.listCommunities();
         assertTrue(o != null && !o.keySet().isEmpty(), "not able to list communities as basic test");
     }
+
+    @Test
+    @Disabled("worked with my personal token, need to dry run with dockstore-bot")
+    public void testZenodoDraftQuery() throws io.swagger.zenodo.client.ApiException {
+        ApiClient client = new ApiClient();
+        String token = "<your token here>>";
+        client.setBasePath("https://zenodo.org/api");
+        if (token != null) {
+            // pretty much need a token to get records for a specific user
+            client.setApiKey(token);
+            PreviewApi previewApi = new PreviewApi(client);
+            // noticed the is_published query fragment from the new api documentation, gives seemingly better results than is_draft
+            Records records = previewApi.listUserRecords("is_published:false", "bestmatch", 10, 1, true, false);
+            // index the various hit ids?
+            Hits hits = records.getHits();
+
+            Set<Integer> draftIds = hits.getHits().stream().map(Hit::getId).collect(Collectors.toSet());
+
+            DepositsApi depositsApi = new DepositsApi(client);
+            for (int depositId : draftIds) {
+                Deposit deposit = depositsApi.getDeposit(depositId);
+                assertEquals((int) deposit.getId(), depositId);
+                // check something with state
+                assertTrue("inprogress".equals(deposit.getState()) || "unsubmitted".equals(deposit.getState()));
+                // then delete them using an undocumented endpoint DELETE https://zenodo.org/api/records/911480/draft
+                try {
+                    previewApi.deleteDraftRecord(depositId);
+                } catch (ApiException e) {
+                    System.out.println("had issues deleting deposit id: " + depositId);
+                }
+            }
+        }
+     }
 }

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -30,10 +30,9 @@ public class ZenodoClientTest {
     }
 
     @Test
-    @Disabled("worked with my personal token, need to dry run with dockstore-bot")
     public void testZenodoDraftQuery() throws io.swagger.zenodo.client.ApiException {
         ApiClient client = new ApiClient();
-        String token = "<your token here>>";
+        String token = "<token>>";
         client.setBasePath("https://zenodo.org/api");
         if (token != null) {
             // pretty much need a token to get records for a specific user

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -30,6 +30,7 @@ public class ZenodoClientTest {
     }
 
     @Test
+    @Disabled("worked with my personal token, need to dry run with dockstore-bot")
     public void testZenodoDraftQuery() throws io.swagger.zenodo.client.ApiException {
         ApiClient client = new ApiClient();
         String token = "<token>>";


### PR DESCRIPTION
**Description**
Demonstrate some partially undocumented endpoints for searching for draft or unsubmitted deposits and then deleting them.

The new API has a partial openapi description at https://inveniosoftware.github.io/invenio-openapi/ it seems to include all endpoints but no return types making code generation not very useful. So rather than start with the openapi generated code (linked), I added a few endpoints I needed to our reverse engineered swagger.yaml which already had some of the return types documented. 

The query language seems based on elasticsearch and there is some partial documentation at https://zenodo.org/help/search but it lacks information on how to narrow down by draft or unpublished states. I tracked that down in an example provided in the openapi.yaml at https://github.com/inveniosoftware/invenio-openapi/blob/master/docs/openapi.yaml#L1770

Separately, the editor https://editor.swagger.io/ is useful for working with openapi.yaml (or swagger.yaml)  while pointing at zenodo.org 

Completely randomly, I encountered a breaking change in the deposit object that is returned. It wasn't broken last week and it is now. That's the addition of a "thumbs" map ... which in retrospect is probably for thumbnail images so we "may" be ok. 

**Review Instructions**
Could use your own token in executable to see your own draft deposits. After review I intend on running against and deleting all in progress deposits (roughly 128) in the dockstore-bot account. 

Output looks like 
```
$ java  -jar target/swagger-java-zenodo-client-2.0.3-SNAPSHOT.jar https://zenodo.org/api  <token>
Aug 19, 2025 4:27:01 P.M. org.glassfish.jersey.client.innate.inject.NonInjectionManager <init>
WARNING: Falling back to injection-less client.
would have deleted deposit id: 16905785
dyuen@phoenix:~/swagger-java-zenodo-client$ java  -jar target/swagger-java-zenodo-client-2.0.3-SNAPSHOT.jar https://zenodo.org/api <token>  live
Aug 19, 2025 4:27:07 P.M. org.glassfish.jersey.client.innate.inject.NonInjectionManager <init>
WARNING: Falling back to injection-less client.
deleted deposit id: 16905785

```

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7226
See also https://github.com/dockstore/openapi-java-invenio-client/pull/1 for an openapi attempt using invenio's provided openapi.yaml

**Security and Privacy**

None

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
