### PR TITLE
fix situation with develop and main

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: '17.0.4+8'
+          java-version: '21.0.2+13.0.LTS'
           distribution: 'adopt'           
       - name: Build with mvn
         run: ./mvnw -B -ntp  clean install

--- a/generated/src/main/resources/pom.xml
+++ b/generated/src/main/resources/pom.xml
@@ -99,6 +99,12 @@
       <version>3.1.0</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonmark</groupId>
+      <artifactId>commonmark</artifactId>
+      <version>0.24.0</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,13 @@
     <properties>
         <github.url>scm:git:git@github.com:dockstore/swagger-java-zenodo-client.git</github.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dockstore-core.version>1.16.0-alpha.13</dockstore-core.version>
-        <maven-failsafe.version>2.21.0</maven-failsafe.version>
+        <dockstore-core.version>1.16.6</dockstore-core.version>
         <maven-surefire.version>3.4.0</maven-surefire.version>
+        <maven-failsafe.version>2.22.2</maven-failsafe.version>
         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-        <jersey-version>3.0.11</jersey-version>
+        <junit-version>4.13.2</junit-version>
+        <jersey.version>3.0.17</jersey.version>
+        <maven-java.version>17</maven-java.version>
     </properties>
 
     <dependencyManagement>
@@ -62,7 +64,7 @@
         <connection>${github.url}</connection>
         <developerConnection>${github.url}</developerConnection>
         <url>${github.url}</url>
-        <tag>swagger-java-bitbucket-client-2.0.0</tag>
+        <tag>swagger-java-zenodo-client-2.0.3</tag>
     </scm>
 
     <licenses>
@@ -87,7 +89,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.5</version>
+                    <version>0.8.11</version>
                 </plugin>
                 <plugin>
                     <groupId>com.googlecode.maven-download-plugin</groupId>
@@ -102,9 +104,9 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
+                    <version>3.12.1</version>
                     <configuration>
-                        <release>17</release>
+                        <release>${maven-java.version}</release>
                         <showDeprecation>true</showDeprecation>
                         <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     </configuration>
@@ -112,7 +114,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.2.2</version>
                     <configuration>
                         <archive>
                             <manifest>
@@ -129,13 +131,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <!-- codacy currently using 8.34 -->
-                            <version>8.34</version>
+                            <version>10.0</version>
                         </dependency>
                     </dependencies>
                     <configuration>
@@ -148,7 +149,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.6.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -247,7 +248,7 @@
                 <plugin>
                     <groupId>com.github.spotbugs</groupId>
                     <artifactId>spotbugs-maven-plugin</artifactId>
-                    <version>4.5.3.0</version>
+                    <version>4.8.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -273,7 +274,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -283,7 +284,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>4.4.1</version>
+                    <version>4.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -293,13 +294,13 @@
                 <plugin>
                     <groupId>io.swagger</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>2.4.21</version>
+                    <version>2.4.32</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/io.swagger.codegen.v3/swagger-codegen-maven-plugin -->
                 <plugin>
                     <groupId>io.swagger.codegen.v3</groupId>
                     <artifactId>swagger-codegen-maven-plugin</artifactId>
-                    <version>3.0.36</version>
+                    <version>3.0.46</version>
                 </plugin>
                 <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/versions-maven-plugin -->
                 <plugin>
@@ -657,6 +658,12 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.24.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -253,23 +253,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.1</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                            <configuration>
-                                <transformers>
-                                    <!-- Akka used by Cromwell expects a consistant reference.conf file.  Also order matters, so keep it first in the list of transformers -->
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
-                                        <resource>reference.conf</resource>
-                                    </transformer>
-                                </transformers>
-                            </configuration>
-                        </execution>
-                    </executions>
+                    <version>3.6.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -590,6 +574,33 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <!-- Akka used by Cromwell expects a consistent reference.conf file.  Also order matters, so keep it first in the list of transformers -->
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                                    <resource>reference.conf</resource>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Main-Class>io.dockstore.DraftCleanup</Main-Class>
+                                    </manifestEntries>
+                                    <mainClass>io.dockstore.DraftCleanup</mainClass>
+                                </transformer>
+                            </transformers>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/dockstore/EntryCreatorExample.java
+++ b/src/main/java/io/dockstore/EntryCreatorExample.java
@@ -18,6 +18,10 @@ import io.swagger.zenodo.client.model.DepositMetadata;
 import io.swagger.zenodo.client.model.DepositionFile;
 import io.swagger.zenodo.client.model.NestedDepositMetadata;
 import io.swagger.zenodo.client.model.RelatedIdentifier;
+import org.commonmark.node.Node;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import java.util.List;
 
 public class EntryCreatorExample {
 
@@ -46,14 +50,102 @@ public class EntryCreatorExample {
         System.out.println(file);
 
         // add some metadata
+        returnDeposit.getMetadata().setPublicationDate("2025-03-03");
         returnDeposit.getMetadata().setTitle("foobar title");
         returnDeposit.getMetadata().setUploadType(DepositMetadata.UploadTypeEnum.POSTER);
-        returnDeposit.getMetadata().setDescription("This is a first upload");
+        // just above https://developers.zenodo.org/#list
+        // there's a note that says " For string fields that allow HTML (e.g. description, notes), for security reasons, only the following tags are accepted: a, abbr, acronym, b, blockquote, br, code, caption, div, em, i, li, ol, p, pre, span, strike, strong, sub, table, caption, tbody, thead, th, td, tr, u, ul. "
+        String descriptionHTML = """
+                <b>This text is bold</b>
+                <strike>This text is scratched out</strike>
+                <p>
+                <strike>This text is also scratched out, but in a new paragraph</strike>            
+            """;
+
+        String descriptionMarkdown = """
+            commonmark-java
+            ===============
+                        
+            Java library for parsing and rendering [Markdown] text according to the
+            [CommonMark] specification (and some extensions).
+                        
+            [![Maven Central status](https://img.shields.io/maven-central/v/org.commonmark/commonmark.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.commonmark%22)
+            [![javadoc](https://www.javadoc.io/badge/org.commonmark/commonmark.svg?color=blue)](https://www.javadoc.io/doc/org.commonmark/commonmark)
+            [![ci](https://github.com/commonmark/commonmark-java/workflows/ci/badge.svg)](https://github.com/commonmark/commonmark-java/actions?query=workflow%3Aci)
+            [![codecov](https://codecov.io/gh/commonmark/commonmark-java/branch/main/graph/badge.svg)](https://codecov.io/gh/commonmark/commonmark-java)
+            [![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/commonmarkcommonmarkjava/)
+                        
+            Introduction
+            ------------
+                        
+            Provides classes for parsing input to an abstract syntax tree (AST),
+            visiting and manipulating nodes, and rendering to HTML or back to Markdown.
+            It started out as a port of [commonmark.js], but has since evolved into an
+            extensible library with the following features:
+                        
+            * Small (core has no dependencies, extensions in separate artifacts)
+            * Fast (10-20 times faster than [pegdown] which used to be a popular Markdown
+              library, see benchmarks in repo)
+            * Flexible (manipulate the AST after parsing, customize HTML rendering)
+            * Extensible (tables, strikethrough, autolinking and more, see below)
+                        
+            The library is supported on Java 11 and later. It works on Android too,
+            but that is on a best-effort basis, please report problems. For Android the
+            minimum API level is 19, see the
+            [commonmark-android-test](commonmark-android-test)
+            directory.
+                        
+            Coordinates for core library (see all on [Maven Central]):
+                        
+            ```xml
+            <dependency>
+                <groupId>org.commonmark</groupId>
+                <artifactId>commonmark</artifactId>
+                <version>0.24.0</version>
+            </dependency>
+            ```
+                        
+            The module names to use in Java 9 are `org.commonmark`,
+            `org.commonmark.ext.autolink`, etc, corresponding to package names.
+                        
+            Note that for 0.x releases of this library, the API is not considered stable
+            yet and may break between minor releases. After 1.0, [Semantic Versioning] will
+            be followed. A package containing `beta` means it's not subject to stable API
+            guarantees yet; but for normal usage it should not be necessary to use.
+                        
+            See the [spec.txt](commonmark-test-util/src/main/resources/spec.txt)
+            file if you're wondering which version of the spec is currently
+            implemented. Also check out the [CommonMark dingus] for getting familiar
+            with the syntax or trying out edge cases. If you clone the repository,
+            you can also use the `DingusApp` class to try out things interactively.
+                        
+                        
+            Usage
+            -----
+                        
+            #### Parse and render to HTML
+                        
+            ```java
+            import org.commonmark.node.*;
+            import org.commonmark.parser.Parser;
+            import org.commonmark.renderer.html.HtmlRenderer;
+                        
+            Parser parser = Parser.builder().build();
+            Node document = parser.parse("This is *Markdown*");
+            HtmlRenderer renderer = HtmlRenderer.builder().build();
+            renderer.render(document);  // "<p>This is <em>Markdown</em></p>\\n"
+            """;
+        Parser parser = Parser.builder().build();
+        Node document = parser.parse(descriptionMarkdown);
+        HtmlRenderer renderer = HtmlRenderer.builder().build();
+        descriptionHTML = renderer.render(document);  // "<p>This is <em>Markdown</em></p>\n"
+
+        returnDeposit.getMetadata().setDescription(descriptionHTML);
 
         RelatedIdentifier relatedIdentifier = new RelatedIdentifier();
         relatedIdentifier.setIdentifier("https://dockstore.org/containers/quay.io%2Fpancancer%2Fpcawg-sanger-cgp-workflow");
         relatedIdentifier.setRelation(RelatedIdentifier.RelationEnum.ISIDENTICALTO);
-        returnDeposit.getMetadata().setRelatedIdentifiers(Arrays.asList(relatedIdentifier));
+        returnDeposit.getMetadata().setRelatedIdentifiers(List.of(relatedIdentifier));
 
         Author author1 = new Author();
         author1.setName("lastname1, firstname1");

--- a/src/main/java/io/dockstore/EntryCreatorExample.java
+++ b/src/main/java/io/dockstore/EntryCreatorExample.java
@@ -160,7 +160,7 @@ public class EntryCreatorExample {
         ActionsApi actionsApi = new ActionsApi(client);
         Deposit publishedDeposit = actionsApi.publishDeposit(depositionID);
 
-        String conceptDoiUrl = publishedDeposit.getLinks().get("parent_doi");
+        String conceptDoiUrl = publishedDeposit.getLinks().getParentDoi();
 
         System.out.println("Success creating concept DOI");
         System.out.println(conceptDoiUrl);
@@ -173,7 +173,7 @@ public class EntryCreatorExample {
 
     public static void testSecondDeposit(DepositsApi depositApi, ActionsApi actionsApi, int depositID) {
         Deposit returnDeposit = actionsApi.newDepositVersion(depositID);
-        String depositURL = returnDeposit.getLinks().get("latest_draft");
+        String depositURL = returnDeposit.getLinks().getLatestDraft();
         String depositionIDStr = depositURL.substring(depositURL.lastIndexOf("/") + 1).trim();
         int depositionID = Integer.parseInt(depositionIDStr);
         returnDeposit = depositApi.getDeposit(depositionID);

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -554,6 +554,84 @@ paths:
             $ref: '#/definitions/SearchResult'
         '405':
           description: Method Not Allowed
+  /records/{depositId}/draft:
+    delete:
+      summary: Delete a draft deposit
+      description: ''
+      operationId: deleteDraftRecord
+      security:
+        - access_token: []
+      tags:
+        - preview
+      parameters:
+        - in: path
+          name: depositId
+          type: integer
+          required: true
+      responses:
+        '204':
+          description: OK
+        '405':
+          description: Method Not Allowed
+  /user/records:
+    get:
+      summary: List of records for a specific user
+      description: ''
+      operationId: listUserRecords
+      security:
+        - access_token: []
+      parameters:
+        - name: q
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Search query used to filter results based on ElasticSearch's
+            query string syntax.
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+          description:
+            'Sort search results. Customizable. Built-in options are "bestmatch",
+                  "newest", "oldest", "updated-desc", "updated-asc", "version", "mostviewed",
+                  "mostdownloaded" (default: "bestmatch" or "newest").'
+        - name: size
+          in: query
+          required: false
+          schema:
+            type: string
+          description: "Specify number of items in the results page (default: 10)."
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+          description: Specify the page of results.
+        - name: allversions
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: "Specify if all versions should be included (default: False, displays just latest version)."
+        - name: shared_with_me
+          in: query
+          required: false
+          schema:
+            type: boolean
+          description: "Seems like undocumented parameter to control if you see everyone's records or just your own"
+      tags:
+        - preview
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: OK
+          schema:
+            $ref: '#/definitions/Records'
+        '405':
+          description: Method Not Allowed
   /records/{id}/access/links:
     post:
       summary: Create an access link
@@ -690,7 +768,26 @@ securityDefinitions:
     name: access_token
     in: query
 definitions:
-  Deposit:
+  Records:
+    type: object
+    properties:
+      hits:
+        $ref: '#/definitions/Hits'
+      aggregations:
+        type: object
+      links:
+        type: object
+  Hits:
+    type: object
+    properties:
+      hits:
+        type: array
+        items:
+          $ref: '#/definitions/Hit'
+      total:
+        type: integer
+  Hit:
+    description: returned by records search, looks a lot like a Deposit but subtly isn't
     type: object
     properties:
       conceptdoi:
@@ -710,6 +807,82 @@ definitions:
         type: object
         additionalProperties:
           type: string
+        example:
+          conceptdoi: https://doi.org/10.5281/zenodo.705645
+      modified:
+        type: string
+        format: date-time
+      owner:
+        type: integer
+      record_id:
+        type: integer
+      state:
+        type: string
+      status:
+        type: string
+        description: oddly, this field is populated in a list of records but not when retriving individual deposits
+      submitted:
+        type: boolean
+      title:
+        type: string
+      doi:
+        type: string
+      doi_url:
+        type: string
+      metadata:
+        type: object
+        properties:
+          related_identifiers:
+            type: array
+            items:
+              $ref: '#/definitions/RelatedIdentifier'
+  Deposit:
+    type: object
+    properties:
+      conceptrecid:
+        type: integer
+      created:
+        type: string
+        format: date-time
+      files:
+        type: array
+        items:
+          $ref: '#/definitions/DepositionFile'
+      id:
+        type: integer
+      links:
+        type: object
+        properties:
+          conceptdoi:
+            type: string
+          self:
+            type: string
+          html:
+            type: string
+          badge:
+            type: string
+          files:
+            type: string
+          bucket:
+            type: string
+          thumb250:
+            type: string
+          thumbs:
+            type: object
+          latest_draft:
+            type: string
+          latest_draft_html:
+            type: string
+          publish:
+            type: string
+          edit:
+            type: string
+          discard:
+            type: string
+          newversion:
+            type: string
+          parent_doi:
+            type: string
         example:
           conceptdoi: https://doi.org/10.5281/zenodo.705645
       metadata:
@@ -1014,30 +1187,6 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/Hit'
-  Hit:
-    type: object
-    properties:
-      id:
-        type: integer
-      created:
-        type: string
-        format: date-time
-      modified:
-        type: string
-        format: date-time
-      doi:
-        type: string
-      doi_url:
-        type: string
-      conceptdoi:
-        type: string
-      metadata:
-        type: object
-        properties:
-          related_identifiers:
-            type: array
-            items:
-              $ref: '#/definitions/RelatedIdentifier'
      
   Record:
     type: object

--- a/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
+++ b/src/main/resources/zenodo-1.0.0-swagger-2.0.yaml
@@ -806,7 +806,7 @@ definitions:
       links:
         type: object
         additionalProperties:
-          type: string
+          type: object
         example:
           conceptdoi: https://doi.org/10.5281/zenodo.705645
       modified:

--- a/src/test/java/io/dockstore/ZenodoClientTest.java
+++ b/src/test/java/io/dockstore/ZenodoClientTest.java
@@ -1,13 +1,21 @@
 package io.dockstore;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.swagger.zenodo.client.ApiClient;
 import io.swagger.zenodo.client.ApiException;
+import io.swagger.zenodo.client.api.DepositsApi;
 import io.swagger.zenodo.client.api.PreviewApi;
+import io.swagger.zenodo.client.model.Deposit;
+import io.swagger.zenodo.client.model.Hit;
+import io.swagger.zenodo.client.model.Hits;
+import io.swagger.zenodo.client.model.Records;
 import io.swagger.zenodo.client.model.SearchResult;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -37,5 +45,39 @@ public class ZenodoClientTest {
         assertNotNull(searchResult.getHits().getHits().get(0).getConceptdoi());
         assertNotNull(searchResult.getHits().getHits().get(0).getCreated());
         assertNotNull(searchResult.getHits().getHits().get(0).getModified());
+    }
+
+
+    @Test
+    @Disabled("worked with my personal token, need to dry run with dockstore-bot")
+    public void testZenodoDraftQuery() throws io.swagger.zenodo.client.ApiException {
+        ApiClient client = new ApiClient();
+        String token = "<<your token here>>";
+        client.setBasePath("https://zenodo.org/api");
+        if (token != null) {
+            // pretty much need a token to get records for a specific user
+            client.setApiKey(token);
+            PreviewApi previewApi = new PreviewApi(client);
+            // noticed the is_published query fragment from the new api documentation, gives seemingly better results than is_draft
+            Records records = previewApi.listUserRecords("is_published:false", "bestmatch", 10, 1, true, false);
+            // index the various hit ids?
+            Hits hits = records.getHits();
+
+            Set<Integer> draftIds = hits.getHits().stream().map(Hit::getId).collect(Collectors.toSet());
+
+            DepositsApi depositsApi = new DepositsApi(client);
+            for (int depositId : draftIds) {
+                Deposit deposit = depositsApi.getDeposit(depositId);
+                assertEquals((int) deposit.getId(), depositId);
+                // check something with state
+                assertTrue("inprogress".equals(deposit.getState()) || "unsubmitted".equals(deposit.getState()));
+                // then delete them using an undocumented endpoint DELETE https://zenodo.org/api/records/911480/draft
+                try {
+                    previewApi.deleteDraftRecord(depositId);
+                } catch (ApiException e) {
+                    System.out.println("had issues deleting deposit id: " + depositId);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
**Description**
Looks like hubflow went awry here (or our understanding of hubflow)
. 
develop is behind main more than main is behind develop (2 vs 19), so replaying develop's two commits in main before doing a release. After approval, will replace develop with main and then do a hubflow release

**Review Instructions**
Will be tested in dockstore hotfix, but could run `testZenodoDraftQuery` (which I did on prod zenodo)

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7226

**Security and Privacy**

None

e.g. Does this change...
* Any user data we collect, or data location?
* Access control, authentication or authorization?
* Encryption features?

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic style checks and unit tests by running `mvn clean install`
- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] Follow the existing JPA patterns for queries, using named parameters, to avoid SQL injection
- [x] If you are changing dependencies, check the Snyk status check or the dashboard to ensure you are not introducing new high/critical vulnerabilities
- [x] Assume that inputs to the API can be malicious, and sanitize and/or check for Denial of Service type values, e.g., massive sizes
- [x] Do not serve user-uploaded binary images through the Dockstore API
- [x] Ensure that endpoints that only allow privileged access enforce that with the `@RolesAllowed` annotation
- [x] Do not create cookies, although this may change in the future
- [x] If this PR is for a user-facing feature, create and link a documentation ticket for this feature (usually in the same milestone as the linked issue). Style points if you create a documentation PR directly and link that instead. 
